### PR TITLE
【WIP】【サーバサイド】ユーザー新規登録、ログイン（メールアドレスのみ）の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,19 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-
+         kanji = /\A[一-龥]+\z/
+         kana = /\A([ァ-ン]|ー)+\z/
+  
   has_many :products
+
+#バリデーション設定   
+  # user_registration1入力項目    
+  validates :name, presence: true, length: { maximum: 15 }
+  validates :family_name, presence: true, length: { maximum: 15 }, format: { with: kanji }
+  validates :first_name, presence: true, length: { maximum: 15 }, format: { with: kanji }
+  validates :family_name_kana, presence: true, length: { maximum: 15 }, format: { with: kana }
+  validates :first_name_kana, presence: true, length: { maximum: 15 }, format: { with: kana }
+  validates :birthday_yyyy, presence: true
+  validates :birthday_mm, presence: true
+  validates :birthday_dd, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,8 +8,7 @@ class User < ApplicationRecord
   
   has_many :products
 
-#バリデーション設定   
-  # user_registration1入力項目    
+#バリデーション設定    
   validates :name, presence: true, length: { maximum: 15 }
   validates :family_name, presence: true, length: { maximum: 15 }, format: { with: kanji }
   validates :first_name, presence: true, length: { maximum: 15 }, format: { with: kanji }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
 
 #バリデーション設定    
   validates :name, presence: true, length: { maximum: 15 }
+  validates :password, presence: true, length: { in: 7..128 },  format: { with: /\A(?=.*[^\d])+/ }
   validates :family_name, presence: true, length: { maximum: 15 }, format: { with: kanji }
   validates :first_name, presence: true, length: { maximum: 15 }, format: { with: kanji }
   validates :family_name_kana, presence: true, length: { maximum: 15 }, format: { with: kana }

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,0 +1,10 @@
+%h2 Resend confirmation instructions
+= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+  = render "devise/shared/error_messages", resource: resource
+  .field
+    = f.label :email
+    %br/
+    = f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email)
+  .actions
+    = f.submit "Resend confirmation instructions"
+= render "devise/shared/links"

--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -1,0 +1,4 @@
+%p
+  Welcome #{@email}!
+%p You can confirm your account email through the link below:
+%p= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token)

--- a/app/views/devise/mailer/email_changed.html.haml
+++ b/app/views/devise/mailer/email_changed.html.haml
@@ -1,0 +1,8 @@
+%p
+  Hello #{@email}!
+- if @resource.try(:unconfirmed_email?)
+  %p
+    We're contacting you to notify you that your email is being changed to #{@resource.unconfirmed_email}.
+- else
+  %p
+    We're contacting you to notify you that your email has been changed to #{@resource.email}.

--- a/app/views/devise/mailer/password_change.html.haml
+++ b/app/views/devise/mailer/password_change.html.haml
@@ -1,0 +1,3 @@
+%p
+  Hello #{@resource.email}!
+%p We're contacting you to notify you that your password has been changed.

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -1,0 +1,6 @@
+%p
+  Hello #{@resource.email}!
+%p Someone has requested a link to change your password. You can do this through the link below.
+%p= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token)
+%p If you didn't request this, please ignore this email.
+%p Your password won't change until you access the link above and create a new one.

--- a/app/views/devise/mailer/unlock_instructions.html.haml
+++ b/app/views/devise/mailer/unlock_instructions.html.haml
@@ -1,0 +1,5 @@
+%p
+  Hello #{@resource.email}!
+%p Your account has been locked due to an excessive number of unsuccessful sign in attempts.
+%p Click the link below to unlock your account:
+%p= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token)

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,0 +1,19 @@
+%h2 Change your password
+= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+  = render "devise/shared/error_messages", resource: resource
+  = f.hidden_field :reset_password_token
+  .field
+    = f.label :password, "New password"
+    %br/
+    - if @minimum_password_length
+      %em
+        (#{@minimum_password_length} characters minimum)
+      %br/
+    = f.password_field :password, autofocus: true, autocomplete: "new-password"
+  .field
+    = f.label :password_confirmation, "Confirm new password"
+    %br/
+    = f.password_field :password_confirmation, autocomplete: "new-password"
+  .actions
+    = f.submit "Change my password"
+= render "devise/shared/links"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,0 +1,10 @@
+%h2 Forgot your password?
+= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+  = render "devise/shared/error_messages", resource: resource
+  .field
+    = f.label :email
+    %br/
+    = f.email_field :email, autofocus: true, autocomplete: "email"
+  .actions
+    = f.submit "Send me reset password instructions"
+= render "devise/shared/links"

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,0 +1,36 @@
+%h2
+  Edit #{resource_name.to_s.humanize}
+= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+  = render "devise/shared/error_messages", resource: resource
+  .field
+    = f.label :email
+    %br/
+    = f.email_field :email, autofocus: true, autocomplete: "email"
+  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+    %div
+      Currently waiting confirmation for: #{resource.unconfirmed_email}
+  .field
+    = f.label :password
+    %i (leave blank if you don't want to change it)
+    %br/
+    = f.password_field :password, autocomplete: "new-password"
+    - if @minimum_password_length
+      %br/
+      %em
+        = @minimum_password_length
+        characters minimum
+  .field
+    = f.label :password_confirmation
+    %br/
+    = f.password_field :password_confirmation, autocomplete: "new-password"
+  .field
+    = f.label :current_password
+    %i (we need your current password to confirm your changes)
+    %br/
+    = f.password_field :current_password, autocomplete: "current-password"
+  .actions
+    = f.submit "Update"
+%h3 Cancel my account
+%p
+  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
+= link_to "Back", :back

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,0 +1,21 @@
+%h2 Sign up
+= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+  = render "devise/shared/error_messages", resource: resource
+  .field
+    = f.label :email
+    %br/
+    = f.email_field :email, autofocus: true, autocomplete: "email"
+  .field
+    = f.label :password
+    - if @minimum_password_length
+      %em
+        (#{@minimum_password_length} characters minimum)
+    %br/
+    = f.password_field :password, autocomplete: "new-password"
+  .field
+    = f.label :password_confirmation
+    %br/
+    = f.password_field :password_confirmation, autocomplete: "new-password"
+  .actions
+    = f.submit "Sign up"
+= render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,0 +1,17 @@
+%h2 Log in
+= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+  .field
+    = f.label :email
+    %br/
+    = f.email_field :email, autofocus: true, autocomplete: "email"
+  .field
+    = f.label :password
+    %br/
+    = f.password_field :password, autocomplete: "current-password"
+  - if devise_mapping.rememberable?
+    .field
+      = f.check_box :remember_me
+      = f.label :remember_me
+  .actions
+    = f.submit "Log in"
+= render "devise/shared/links"

--- a/app/views/devise/shared/_error_messages.html.haml
+++ b/app/views/devise/shared/_error_messages.html.haml
@@ -1,0 +1,9 @@
+- if resource.errors.any?
+  #error_explanation
+    %h2
+      = I18n.t("errors.messages.not_saved",                 |
+        count: resource.errors.count,                       |
+        resource: resource.class.model_name.human.downcase) |
+    %ul
+      - resource.errors.full_messages.each do |message|
+        %li= message

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,0 +1,19 @@
+- if controller_name != 'sessions'
+  = link_to "Log in", new_session_path(resource_name)
+  %br/
+- if devise_mapping.registerable? && controller_name != 'registrations'
+  = link_to "Sign up", new_registration_path(resource_name)
+  %br/
+- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+  = link_to "Forgot your password?", new_password_path(resource_name)
+  %br/
+- if devise_mapping.confirmable? && controller_name != 'confirmations'
+  = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
+  %br/
+- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
+  = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
+  %br/
+- if devise_mapping.omniauthable?
+  - resource_class.omniauth_providers.each do |provider|
+    = link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)
+    %br/

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -1,0 +1,10 @@
+%h2 Resend unlock instructions
+= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
+  = render "devise/shared/error_messages", resource: resource
+  .field
+    = f.label :email
+    %br/
+    = f.email_field :email, autofocus: true, autocomplete: "email"
+  .actions
+    = f.submit "Resend unlock instructions"
+= render "devise/shared/links"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,10 +6,10 @@ FactoryBot.define do
     email {Faker::Internet.free_email}
     password {password}
     password_confirmation {password}
-    family_name  {"hoge"}     
-    first_name  {"hoge"}      
-    family_name_kana {"hoge"}      
-    first_name_kana   {"hoge"}      
+    family_name  {"山田"}     
+    first_name  {"真之介"}      
+    family_name_kana {"ヤマダ"}      
+    first_name_kana   {"シンノスケ"}      
     birthday_yyyy   {2000}  
     birthday_mm     {01}    
     birthday_dd      {01}    

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,13 +22,6 @@ RSpec.describe User, type: :model do
       expect(user.errors[:email]).to include("can't be blank")
     end
 
-    it "emailが重複すると登録不可" do
-      create(:user)
-      another_user = build(:user)
-      another_user.valid?
-      expect(another_user.errors[:email]).to include("has already been taken")
-    end
-
     it "emailが@を含まないと登録不可 " do
       user = build(:user, email: "aaaaa")
       user.valid?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,179 @@
+require 'rails_helper'
+
+
+RSpec.describe User, type: :model do
+  describe '#create' do
+
+    it "nameが空では登録不可" do
+      user = build(:user, name: nil)
+      user.valid?
+      expect(user.errors[:name]).to include("can't be blank")
+    end
+
+    it "nameが16文字以上だと登録不可" do
+      user = build(:user, name: "aaaaaaaaaaaaaaaaa")
+      user.valid?
+      expect(user.errors[:name][0]).to include("is too long (maximum is 15 characters)")
+    end
+
+    it "emailが空では登録不可" do
+      user = build(:user, email: "")
+      user.valid?
+      expect(user.errors[:email]).to include("can't be blank")
+    end
+
+    it "emailが重複すると登録不可" do
+      create(:user)
+      another_user = build(:user)
+      another_user.valid?
+      expect(another_user.errors[:email]).to include("has already been taken")
+    end
+
+    it "emailが@を含まないと登録不可 " do
+      user = build(:user, email: "aaaaa")
+      user.valid?
+      expect(user.errors[:email][0]).to include("is invalid")
+    end
+
+    it "emailの@の前に文字がないと登録不可 " do
+      user = build(:user, email: "@aaa")
+      user.valid?
+      expect(user.errors[:email][0]).to include("is invalid")
+    end
+
+    it "emailの@の後に文字がないと登録不可" do
+      user = build(:user, email: "aaaa@")
+      user.valid?
+      expect(user.errors[:email][0]).to include("is invalid")
+    end
+
+
+    it "passwordが空だと登録不可" do
+      user = build(:user, password: nil)
+      user.valid?
+      expect(user.errors[:password]).to include("can't be blank")
+    end
+
+
+    it "password_confirmationが一致しないと登録不可" do
+      user = build(:user, password_confirmation: "")
+      user.valid?
+      expect(user.errors[:password_confirmation]).to include("doesn't match Password")
+    end
+
+
+    it "passwordが6文字以下だと登録不可" do
+      user = build(:user, password: "000000", password_confirmation: "000000")
+      user.valid?
+      expect(user.errors[:password]).to include("is too short (minimum is 7 characters)")
+    end
+
+
+    it "first_nameが空だと登録不可" do
+      user = build(:user, first_name: nil)
+      user.valid?
+      expect(user.errors[:first_name]).to include("can't be blank")
+    end
+
+
+    it "first_nameが16文字以上だと登録不可" do
+      user = build(:user, first_name: "瀬瀬瀬瀬瀬瀬瀬瀬瀬瀬瀬瀬瀬瀬瀬瀬")
+      user.valid?
+      expect(user.errors[:first_name][0]).to include("is too long (maximum is 15 characters)")
+    end
+
+
+    it "first_nameに漢字以外が含まれると登録不可 " do
+      user = build(:user, first_name: "瀬瀬a")
+      user.valid?
+      expect(user.errors[:first_name][0]).to include("is invalid")
+    end
+
+    it "family_nameが空だと登録不可" do
+      user = build(:user, family_name: nil)
+      user.valid?
+      expect(user.errors[:family_name]).to include("can't be blank")
+    end
+
+    it "family_nameが16文字以上だと登録不可" do
+      user = build(:user, family_name: "瀬瀬瀬瀬瀬瀬瀬瀬瀬瀬瀬瀬瀬瀬瀬瀬")
+      user.valid?
+      expect(user.errors[:family_name][0]).to include("is too long (maximum is 15 characters)")
+    end
+
+
+    it "family_nameに漢字以外が含まれると登録不可 " do
+      user = build(:user, family_name: "瀬瀬a")
+      user.valid?
+      expect(user.errors[:family_name][0]).to include("is invalid")
+    end
+
+
+    it "first_name_kanaが空だと登録不可" do
+      user = build(:user, first_name_kana: nil)
+      user.valid?
+      expect(user.errors[:first_name_kana]).to include("can't be blank")
+    end
+
+
+    it "first_name_kanaが16文字以上だと登録不可" do
+      user = build(:user, first_name_kana: "アアアアアアアアアアアアアアアア")
+      user.valid?
+      expect(user.errors[:first_name_kana][0]).to include("is too long (maximum is 15 characters)")
+    end
+
+
+    it "first_name_kanaにカナ以外が含まれると登録不可 " do
+      user = build(:user, first_name_kana: "トトa")
+      user.valid?
+      expect(user.errors[:first_name_kana][0]).to include("is invalid")
+    end
+
+
+    it "family_name_kanaが空だと登録不可" do
+      user = build(:user, family_name_kana: nil)
+      user.valid?
+      expect(user.errors[:family_name_kana]).to include("can't be blank")
+    end
+
+
+    it "family_name_kanaが16文字以上だと登録不可" do
+      user = build(:user, family_name_kana: "ウアウアウアウアウアウアウアウア")
+      user.valid?
+      expect(user.errors[:family_name_kana][0]).to include("is too long (maximum is 15 characters)")
+    end
+
+
+    it "family_name_kanaにカナ以外が含まれると登録不可 " do
+      user = build(:user, family_name_kana: "カナa")
+      user.valid?
+      expect(user.errors[:family_name_kana][0]).to include("is invalid")
+    end
+
+
+    it "birthday_yyyyが空だと登録不可" do
+      user = build(:user, birthday_yyyy: nil)
+      user.valid?
+      expect(user.errors[:birthday_yyyy]).to include("can't be blank")
+    end
+
+    it "birthday_mmが空だと登録不可" do
+      user = build(:user, birthday_mm: nil)
+      user.valid?
+      expect(user.errors[:birthday_mm]).to include("can't be blank")
+    end
+
+    it "birthday_ddが空だと登録不可" do
+      user = build(:user, birthday_dd: nil)
+      user.valid?
+      expect(user.errors[:birthday_dd]).to include("can't be blank")
+    end
+
+    it "すべて満たしていれば登録可" do
+      user = build(:user)
+      expect(user).to be_valid
+    end
+
+
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
+  config.include FactoryBot::Syntax::Methods
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your


### PR DESCRIPTION
#Why
マークアップ済みのメルカリのユーザー新規登録/ログインページに機能を実装するため、サーバーサイドを設定する。

#What
deviceを使ったuserテーブルの作成
バリデーション設定
単体テスト